### PR TITLE
🐳 Fix caching of server binary in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ RUN apt-get update -y && \
     apt-get install --no-install-recommends -y texlive-xetex && \
     rm -rf /var/lib/apt/lists/
 
-COPY target/release/papers-server .
+COPY target/release .
 
 CMD ./papers-server


### PR DESCRIPTION
The file with the nice name in target/release is actually a symlink.
Solution: copy the whole release directory.