### PR TITLE
🐛 Use V4 UUIDs instead of original file names for merge assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## Unreleased
 
+## [0.3.1] - 2018-08-27
+- Save merge assets with V4 UUIDs as file names instead of using the original
+  file names to avoid errors when users upload files with the same name.
+
 ## [0.3.0] - 2018-05-11
 - Add Sentry for error tracking
 - Make `papers local` exit with same code as the latex process

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "papers"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -826,6 +826,7 @@ dependencies = [
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-process 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "papers"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     "Peter Gundel <peter.gundel@store2be.com",
     "Fausto Núñez Alberro <fausto.nunez@store2be.com>",
@@ -36,6 +36,7 @@ tokio-core = "0.1.10"
 tokio-io = "0.1.4"
 tokio-process = "0.1.4"
 sentry = { git = "https://github.com/getsentry/sentry-rust", tag = "0.5.1" }
+uuid = { version = "0.6", features = ["v4"] }
 
 [dependencies.slog]
 version = "^2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ extern crate tera;
 extern crate tokio_core;
 extern crate tokio_io;
 extern crate tokio_process;
+extern crate uuid;
 
 pub mod config;
 pub mod error;


### PR DESCRIPTION
This prevents errors when a user uploads files with the same name.