### PR TITLE
🐛 Reject merge requests with an empty document list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - sudo apt-get update && sudo apt-get install imagemagick poppler-utils
 script:
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (cargo clippy) fi
-  - if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then (cargo fmt -- --write-mode=diff) fi
+  - if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then (cargo fmt --all -- --check) fi
   - cargo build
   - cargo test
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ rust:
 cache: cargo
 before_script:
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (cargo install clippy --force) fi
-  - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (cargo install rustfmt-nightly --force) fi
+  - if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then (rustup component add rustfmt-preview) fi
   - sudo apt-get update && sudo apt-get install imagemagick poppler-utils
 script:
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (cargo clippy) fi
-  - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (cargo fmt -- --write-mode=diff) fi
+  - if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then (cargo fmt -- --write-mode=diff) fi
   - cargo build
   - cargo test
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rust:
   - nightly
 cache: cargo
 before_script:
-  - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (cargo install clippy --force) fi
+  - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then (rustup component add clippy-preview) fi
   - if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then (rustup component add rustfmt-preview) fi
   - sudo apt-get update && sudo apt-get install imagemagick poppler-utils
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 
 ## Unreleased
 
-## [0.3.1] - 2018-08-27
-- Save merge assets with V4 UUIDs as file names instead of using the original
-  file names to avoid errors when users upload files with the same name.
+### Fixes
+
+- Save merge assets with V4 UUIDs as file names instead of using the original file names to avoid errors when users upload files with the same name.
+- Reject merge requests with an empty list of documents to merge
 
 ## [0.3.0] - 2018-05-11
 - Add Sentry for error tracking

--- a/src/http.rs
+++ b/src/http.rs
@@ -39,7 +39,8 @@ impl ResponseExt for Response {
 
     fn with_file_unsafe(self, path: &Path) -> Self {
         let mut body: Vec<u8> = Vec::new();
-        let filename = path.file_name()
+        let filename = path
+            .file_name()
             .unwrap()
             .to_string_lossy()
             .into_owned()

--- a/src/local_server.rs
+++ b/src/local_server.rs
@@ -18,7 +18,8 @@ fn render(document_spec: DocumentSpec) -> ::std::process::ExitStatus {
     let mut tera = make_tera();
     tera.add_raw_template("template", &template_string)
         .expect("failed to add raw template");
-    let rendered_template = tera.render("template", &variables)
+    let rendered_template = tera
+        .render("template", &variables)
         .expect("failed to render the template");
     let mut rendered_template_file =
         ::std::fs::File::create("rendered.tex").expect("could not create rendered.tex");

--- a/src/papers/merge.rs
+++ b/src/papers/merge.rs
@@ -1,6 +1,5 @@
 use mktemp::Temp;
 
-use std::ffi::{OsStr};
 use config::Config;
 use error::{Error, ErrorKind};
 use futures::*;
@@ -9,6 +8,7 @@ use http::*;
 use hyper::client::*;
 use papers::MergeSpec;
 use slog::Logger;
+use std::ffi::OsStr;
 use std::io::prelude::*;
 use std::path::*;
 use std::process::Command;
@@ -77,7 +77,11 @@ pub fn merge_documents(
 
                         // Files are saved with a UUID as a filename to avoid
                         // errors when users upload files with the same name
-                        path.push(filename_path_buf.with_file_name(Uuid::new_v4().to_string()).with_extension(extension));
+                        path.push(
+                            filename_path_buf
+                                .with_file_name(Uuid::new_v4().to_string())
+                                .with_extension(extension),
+                        );
 
                         debug!(logger, "Writing file {:?} as {:?}", &uri, &path);
                         ::std::fs::File::create(&path)

--- a/src/papers/mod.rs
+++ b/src/papers/mod.rs
@@ -182,7 +182,8 @@ where
                         Renderer::new(config, handle, client).preview(document_spec, sender)
                     });
                     ok(())
-                }).and_then(move |_| receiver.map_err(|err| panic!(err)))
+                })
+                .and_then(move |_| receiver.map_err(|err| panic!(err)))
                 .flatten()
         };
 
@@ -217,7 +218,8 @@ where
                             err,
                             ErrorKind::UnprocessableEntity("Merge Spec failed".to_string()),
                         )
-                    }).and_then(|merge_spec| {
+                    })
+                    .and_then(|merge_spec| {
                         merge_spec.validate()?;
                         Ok(merge_spec)
                     }),

--- a/src/papers/mod.rs
+++ b/src/papers/mod.rs
@@ -182,8 +182,7 @@ where
                         Renderer::new(config, handle, client).preview(document_spec, sender)
                     });
                     ok(())
-                })
-                .and_then(move |_| receiver.map_err(|err| panic!(err)))
+                }).and_then(move |_| receiver.map_err(|err| panic!(err)))
                 .flatten()
         };
 
@@ -212,12 +211,16 @@ where
         let body = req.get_body_bytes();
         let merge_spec = body.and_then(|body| {
             result(
-                serde_json::from_slice::<MergeSpec>(body.as_slice()).map_err(|err| {
-                    Error::with_chain(
-                        err,
-                        ErrorKind::UnprocessableEntity("Merge Spec failed".to_string()),
-                    )
-                }),
+                serde_json::from_slice::<MergeSpec>(body.as_slice())
+                    .map_err(|err| {
+                        Error::with_chain(
+                            err,
+                            ErrorKind::UnprocessableEntity("Merge Spec failed".to_string()),
+                        )
+                    }).and_then(|merge_spec| {
+                        merge_spec.validate()?;
+                        Ok(merge_spec)
+                    }),
             )
         });
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -116,9 +116,9 @@ where
         let logger = file_logger(self.config.logger.clone(), &temp_dir_path);
 
         let mut template_path = temp_dir_path.clone();
-        template_path.push(Path::new(&document_spec
-            .output_filename
-            .replace("pdf", "tex")));
+        template_path.push(Path::new(
+            &document_spec.output_filename.replace("pdf", "tex"),
+        ));
         let max_asset_size = self.config.max_asset_size;
 
         debug!(

--- a/src/utils/templating.rs
+++ b/src/utils/templating.rs
@@ -49,7 +49,8 @@ mod tests {
         });
         tera.add_raw_template("template", TEMPLATE)
             .expect("failed to add raw template");
-        let rendered_template = tera.render("template", &variables)
+        let rendered_template = tera
+            .render("template", &variables)
             .expect("failed to render the template");
         assert_eq!(rendered_template, EXPECTED_TEMPLATE_RESULT);
     }
@@ -78,7 +79,8 @@ mod tests {
         });
         tera.add_raw_template("template", TEMPLATE)
             .expect("failed to add raw template");
-        let rendered_template = tera.render("template", &variables)
+        let rendered_template = tera
+            .render("template", &variables)
             .expect("failed to render the template");
         assert_eq!(rendered_template, EXPECTED_TEMPLATE_RESULT);
     }

--- a/tests/merge/end_to_end.rs
+++ b/tests/merge/end_to_end.rs
@@ -55,19 +55,23 @@ impl server::Service for MockServer {
                     .get_body_bytes()
                     .and_then(|bytes| {
                         ok(json::from_slice::<Summary>(&bytes).expect("could not read summary"))
-                    }).map(|summary| {
+                    })
+                    .map(|summary| {
                         if let Summary::Error { error: err, .. } = summary {
                             panic!("Error reported to callback endpoint: {}", err);
                         }
                         summary
-                    }).and_then(move |_| {
+                    })
+                    .and_then(move |_| {
                         sender
                             .send("callback ok")
                             .map_err(|_| ErrorKind::InternalServerError.into())
-                    }).and_then(|_| {
+                    })
+                    .and_then(|_| {
                         println!("Sending back response from callback endpoint");
                         ok(server::Response::new())
-                    }).map_err(|_| hyper::Error::Incomplete);
+                    })
+                    .map_err(|_| hyper::Error::Incomplete);
                 Box::new(res)
             }
             other => panic!("Unexpected request to {}", other),
@@ -94,7 +98,8 @@ pub fn test_end_to_end() {
             .bind(
                 &format!("127.0.0.1:{}", mock_port).parse().unwrap(),
                 move || Ok(MockServer::new(sender.clone())),
-            ).expect("could not bind")
+            )
+            .expect("could not bind")
             .run()
     });
 
@@ -119,7 +124,7 @@ pub fn test_end_to_end() {
             .parse()
             .unwrap(),
     ).with_body(merge_spec.into())
-    .with_header(ContentType(mime::APPLICATION_JSON));
+        .with_header(ContentType(mime::APPLICATION_JSON));
 
     let test = test_client.request(request);
 
@@ -186,7 +191,7 @@ pub fn test_rejection() {
             .parse()
             .unwrap(),
     ).with_body(merge_spec.into())
-    .with_header(ContentType(mime::APPLICATION_JSON));
+        .with_header(ContentType(mime::APPLICATION_JSON));
 
     let test = test_client.request(request);
 

--- a/tests/merge/end_to_end.rs
+++ b/tests/merge/end_to_end.rs
@@ -161,7 +161,6 @@ pub fn test_end_to_end() {
 
 pub fn test_rejection() {
     let pool = CpuPool::new(3);
-    let (_sender, receiver) = mpsc::channel(30);
 
     let papers_port = toolbox::random_port();
 
@@ -195,19 +194,8 @@ pub fn test_rejection() {
 
     let test = test_client.request(request);
 
-    let expected_messages: Vec<Result<Message, ()>> = vec![].into_iter().map(Ok).collect();
-
-    let expectations = receiver
-        .take(expected_messages.len() as u64)
-        .zip(futures::stream::iter_ok(expected_messages))
-        .for_each(|(message, expected)| {
-            assert_eq!(Ok(message), expected);
-            ok(())
-        });
-
     // Request + expectations
     let tests = test.map_err(|err| panic!("Test error: {}", err))
-        .and_then(|res| expectations.map(|_| res))
         // Crash if any of the servers panicked
         .then(move |res| {
             if let Err(e) = join_papers.poll() {

--- a/tests/submit/end_to_end.rs
+++ b/tests/submit/end_to_end.rs
@@ -154,7 +154,8 @@ pub fn test_end_to_end() {
         });
 
     // Request + expectations
-    let tests = test.map_err(|err| println!("Test error: {}", err))
+    let tests = test
+        .map_err(|err| println!("Test error: {}", err))
         .and_then(|res| expectations.map(|_| res));
 
     let (status, body) = core.run(tests).expect("tests failed");

--- a/tests/template.rs
+++ b/tests/template.rs
@@ -76,13 +76,14 @@ fn test_simple_template_preview() {
 
     let papers: Papers<MockServer> = Papers::new(core.remote(), &CONFIG);
     let response = papers.call(request).map_err(|_| ());
-    let (body, status) = core.run(response.and_then(|response| {
-        let status = response.status();
-        response
-            .get_body_bytes()
-            .map(move |body| (body, status))
-            .map_err(|_| ())
-    })).unwrap();
+    let (body, status) =
+        core.run(response.and_then(|response| {
+            let status = response.status();
+            response
+                .get_body_bytes()
+                .map(move |body| (body, status))
+                .map_err(|_| ())
+        })).unwrap();
     assert_eq!(status, hyper::StatusCode::Ok);
     assert_eq!(
         ::std::str::from_utf8(&body).unwrap(),

--- a/tests/test_merge.rs
+++ b/tests/test_merge.rs
@@ -15,3 +15,8 @@ mod toolbox;
 fn test_merge() {
     merge::end_to_end::test_end_to_end();
 }
+
+#[test]
+fn test_merge_rejection() {
+    merge::end_to_end::test_rejection();
+}


### PR DESCRIPTION
This makes the whole process fail earlier and gives better feedback.

A lot of the diff is from switching to the stable version of rustfmt.